### PR TITLE
fix: typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project makes no assumptions about the styling required for a particular pr
 ### Install
 
 ```bash
-npm install simple-vue --save
+npm install simple-vues --save
 ```
 
 ### Import


### PR DESCRIPTION
The package name was incorrectly specified as `simple-vue` in the README.md file.
This change corrects it to `simple-vues`